### PR TITLE
Fix clippy warnings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,13 +173,13 @@ pub enum Item<'a> {
 impl<'a> fmt::Display for Item<'a> {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
 		match self {
-			&Item::Error(error) => write!(f, "{}\n", error),
-			&Item::Section(section) => write!(f, "[{}]\n", section),
-			&Item::SectionEnd => Ok(()),
-			&Item::Property(key, Some(value)) => write!(f, "{}={}\n", key, value),
-			&Item::Property(key, None) => write!(f, "{}\n", key),
-			&Item::Comment(comment) => write!(f, ";{}\n", comment),
-			&Item::Blank => f.write_str("\n"),
+			Item::Error(error) => writeln!(f, "{}", error),
+			Item::Section(section) => writeln!(f, "[{}]", section),
+			Item::SectionEnd => Ok(()),
+			Item::Property(key, Some(value)) => writeln!(f, "{}={}", key, value),
+			Item::Property(key, None) => writeln!(f, "{}", key),
+			Item::Comment(comment) => writeln!(f, ";{}", comment),
+			Item::Blank => f.write_str("\n"),
 		}
 	}
 }
@@ -335,15 +335,13 @@ impl<'a> core::iter::FusedIterator for Parser<'a> {}
 impl<'a> Parser<'a> {
 	#[inline]
 	fn skip_ln(&mut self, mut s: &'a [u8]) {
-		if s.len() > 0 {
+		if !s.is_empty() {
 			if s[0] == b'\r' {
 				s = &s[1..];
 			}
-			if s.len() > 0 {
-				if s[0] == b'\n' {
-					s = &s[1..];
-				}
-			}
+			if !s.is_empty() && s[0] == b'\n' {
+   					s = &s[1..];
+   				}
 			self.line += 1;
 		}
 		self.state = s;

--- a/src/parse/avx2.rs
+++ b/src/parse/avx2.rs
@@ -31,7 +31,7 @@ pub fn find_nl(s: &[u8]) -> usize {
 	unsafe_assert!(offset <= s.len());
 	offset += super::generic::find_nl(&s[offset..]);
 	unsafe_assert!(offset <= s.len());
-	return offset;
+	offset
 }
 
 #[inline]
@@ -63,5 +63,5 @@ pub fn find_nl_chr(s: &[u8], chr: u8) -> usize {
 	unsafe_assert!(offset <= s.len());
 	offset += super::generic::find_nl_chr(&s[offset..], chr);
 	unsafe_assert!(offset <= s.len());
-	return offset;
+	offset
 }

--- a/src/parse/generic.rs
+++ b/src/parse/generic.rs
@@ -9,7 +9,7 @@ pub fn find_nl(s: &[u8]) -> usize {
 		i += 1;
 	}
 	unsafe_assert!(i <= s.len());
-	return i;
+	i
 }
 
 #[inline]
@@ -22,5 +22,5 @@ pub fn find_nl_chr(s: &[u8], chr: u8) -> usize {
 		i += 1;
 	}
 	unsafe_assert!(i <= s.len());
-	return i;
+	i
 }

--- a/src/parse/sse2.rs
+++ b/src/parse/sse2.rs
@@ -31,7 +31,7 @@ pub fn find_nl(s: &[u8]) -> usize {
 	unsafe_assert!(offset <= s.len());
 	offset += super::generic::find_nl(&s[offset..]);
 	unsafe_assert!(offset <= s.len());
-	return offset;
+	offset
 }
 
 #[inline]
@@ -63,5 +63,5 @@ pub fn find_nl_chr(s: &[u8], chr: u8) -> usize {
 	unsafe_assert!(offset <= s.len());
 	offset += super::generic::find_nl_chr(&s[offset..], chr);
 	unsafe_assert!(offset <= s.len());
-	return offset;
+	offset
 }

--- a/src/parse/swar32.rs
+++ b/src/parse/swar32.rs
@@ -18,7 +18,7 @@ pub fn find_nl(s: &[u8]) -> usize {
 	unsafe_assert!(offset <= s.len());
 	offset += super::generic::find_nl(&s[offset..]);
 	unsafe_assert!(offset <= s.len());
-	return offset;
+	offset
 }
 
 #[inline]
@@ -41,7 +41,7 @@ pub fn find_nl_chr(s: &[u8], chr: u8) -> usize {
 	unsafe_assert!(offset <= s.len());
 	offset += super::generic::find_nl_chr(&s[offset..], chr);
 	unsafe_assert!(offset <= s.len());
-	return offset;
+	offset
 }
 
 #[inline]

--- a/src/parse/swar64.rs
+++ b/src/parse/swar64.rs
@@ -18,7 +18,7 @@ pub fn find_nl(s: &[u8]) -> usize {
 	unsafe_assert!(offset <= s.len());
 	offset += super::generic::find_nl(&s[offset..]);
 	unsafe_assert!(offset <= s.len());
-	return offset;
+	offset
 }
 
 #[inline]
@@ -41,7 +41,7 @@ pub fn find_nl_chr(s: &[u8], chr: u8) -> usize {
 	unsafe_assert!(offset <= s.len());
 	offset += super::generic::find_nl_chr(&s[offset..], chr);
 	unsafe_assert!(offset <= s.len());
-	return offset;
+	offset
 }
 
 #[inline]


### PR DESCRIPTION
Fix all default level `cargo clippy` warnings except those about using tabs in doc comments (I assume you wanted to deviate from the standard there, as you use tabs consistently for indentation across the project).